### PR TITLE
[#2] Show app logo running in the tab bar (SUB)

### DIFF
--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -1,7 +1,7 @@
 import SwiftUI
 
 struct ContentView: View {
-  @StateObject private var sublifyManager = SublifyManager()
+  @StateObject private var sublifyManager = SublifyManagerShared.shared
   @State private var showingSettings = false
 
   var body: some View {

--- a/Sources/SettingsView.swift
+++ b/Sources/SettingsView.swift
@@ -18,6 +18,8 @@ struct SettingsView: View {
           ContentSection(sublifyManager: sublifyManager, showingImagePicker: $showingImagePicker)
 
           AppearanceSection(sublifyManager: sublifyManager)
+          
+          BehaviorSection(sublifyManager: sublifyManager)
 
           PreviewSection(sublifyManager: sublifyManager, testDisplay: testDisplay)
         }
@@ -569,6 +571,106 @@ struct FontSizeItem: View {
   }
 }
 
+// MARK: - Behavior Section
+struct BehaviorSection: View {
+  @ObservedObject var sublifyManager: SublifyManager
+
+  var body: some View {
+    VStack(alignment: .leading, spacing: SublifySpacing.md) {
+      Label {
+        Text("App Behavior")
+          .font(.sublifyH4)
+          .foregroundColor(.sublifyText)
+      } icon: {
+        Image(systemName: "gear.circle.fill")
+          .foregroundColor(.sublifyPrimary)
+          .font(.system(size: 14))
+      }
+
+      VStack(spacing: 0) {
+        BehaviorToggleRow(
+          title: "Show in Menu Bar",
+          subtitle: "Display app icon in the menu bar for quick access",
+          icon: "menubar.rectangle",
+          isOn: $sublifyManager.settings.showInMenuBar,
+          onChange: { _ in
+            updateDockAndMenuBar()
+          }
+        )
+
+        Divider()
+          .background(Color.sublifyBorder.opacity(0.5))
+
+        BehaviorToggleRow(
+          title: "Hide from Dock",
+          subtitle: "Remove app icon from the Dock when running",
+          icon: "dock.rectangle",
+          isOn: $sublifyManager.settings.hideFromDock,
+          onChange: { _ in
+            updateDockAndMenuBar()
+          }
+        )
+      }
+      .cornerRadius(SublifyRadius.lg)
+      .overlay(
+        RoundedRectangle(cornerRadius: SublifyRadius.lg)
+          .stroke(Color.sublifyBorder.opacity(0.3), lineWidth: 1)
+      )
+    }
+  }
+  
+  private func updateDockAndMenuBar() {
+    // Update dock and menu bar visibility
+    DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
+      if let appDelegate = NSApp.delegate as? AppDelegate {
+        appDelegate.updateDockAndMenuBarVisibility()
+      }
+    }
+  }
+}
+
+// MARK: - Behavior Toggle Row
+struct BehaviorToggleRow: View {
+  let title: String
+  let subtitle: String
+  let icon: String
+  @Binding var isOn: Bool
+  let onChange: (Bool) -> Void
+
+  var body: some View {
+    HStack {
+      HStack(spacing: SublifySpacing.sm) {
+        Image(systemName: icon)
+          .foregroundColor(.sublifyPrimary.opacity(0.8))
+          .font(.system(size: 12))
+          .frame(width: 16)
+
+        VStack(alignment: .leading, spacing: 2) {
+          Text(title)
+            .font(.system(size: 13, weight: .medium))
+            .foregroundColor(.sublifyText)
+          Text(subtitle)
+            .font(.system(size: 11))
+            .foregroundColor(.sublifyTextSecondary)
+        }
+      }
+
+      Spacer()
+
+      Toggle("", isOn: Binding(
+        get: { isOn },
+        set: { newValue in
+          isOn = newValue
+          onChange(newValue)
+        }
+      ))
+        .toggleStyle(SublifyToggleStyle())
+    }
+    .padding(SublifySpacing.md)
+    .background(Color.sublifyCardBackground)
+  }
+}
+
 // MARK: - Preview Section
 struct PreviewSection: View {
   @ObservedObject var sublifyManager: SublifyManager
@@ -679,5 +781,5 @@ extension NSClickGestureRecognizer {
 }
 
 private struct AssociatedKeys {
-  static var handler = "handler"
+  static var handler: UInt8 = 0
 }

--- a/Sources/SublifyApp.swift
+++ b/Sources/SublifyApp.swift
@@ -1,5 +1,10 @@
 import SwiftUI
 
+// Global SublifyManager instance
+class SublifyManagerShared {
+  static let shared = SublifyManager()
+}
+
 @main
 struct SublifyApp: App {
   @NSApplicationDelegateAdaptor(AppDelegate.self) var appDelegate
@@ -15,11 +20,11 @@ struct SublifyApp: App {
 
 class AppDelegate: NSObject, NSApplicationDelegate {
   func applicationDidFinishLaunching(_ notification: Notification) {
-    // Show dock icon for testing
-    NSApp.setActivationPolicy(.regular)
-
     // Set the app icon programmatically
     setAppIcon()
+    
+    // Configure dock and menu bar based on settings
+    configureDockAndMenuBar()
   }
 
   func applicationShouldTerminateAfterLastWindowClosed(_ app: NSApplication) -> Bool {
@@ -50,5 +55,25 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     }
 
     print("⚠️ Could not find app icon file")
+  }
+  
+  private func configureDockAndMenuBar() {
+    let manager = SublifyManagerShared.shared
+    
+    // Configure dock visibility
+    if manager.settings.hideFromDock {
+      NSApp.setActivationPolicy(.accessory)
+    } else {
+      NSApp.setActivationPolicy(.regular)
+    }
+    
+    // Setup menu bar if requested
+    if manager.settings.showInMenuBar {
+      manager.setupMenuBar()
+    }
+  }
+  
+  func updateDockAndMenuBarVisibility() {
+    configureDockAndMenuBar()
   }
 }


### PR DESCRIPTION
Schließt: #2

### In diesem PR:
- [x] Add showInMenuBar and hideFromDock settings to SublifySettings → adf03dc
- [x] Implement NSStatusItem with menu functionality for menu bar → adf03dc
- [x] Add dock activation policy management in AppDelegate → adf03dc
- [x] Create BehaviorSection in SettingsView with toggle controls → adf03dc
- [x] Enable real-time dock/menu bar visibility updates → adf03dc

### Funktionen:

**Menu Bar Integration:**
- App icon appears in menu bar when enabled
- Click menu bar icon to access app controls
- Status display shows "Active" or "Inactive" 
- Quick Start/Stop functionality from menu bar
- "Show Sublify" to bring main window to front
- Quit option with proper cleanup

**Dock Visibility Control:**
- Option to hide app from Dock completely
- Uses NSApp.setActivationPolicy(.accessory) when hidden
- Seamless transition between dock and menu bar only modes

**Settings UI:**
- New "App Behavior" section in Settings
- Toggle controls for "Show in Menu Bar" and "Hide from Dock"
- Real-time updates - changes apply immediately
- Descriptive labels explaining each option

**Technical Implementation:**
- Shared SublifyManager instance for consistent state
- Proper menu bar icon resizing (18x18px)
- Fallback to SF Symbol if app icon unavailable
- Menu refreshes automatically when app state changes
- Settings persist across app restarts